### PR TITLE
Fix typo in 1. Beginning with Python.ipynb

### DIFF
--- a/notebooks/1. Beginning with Python.ipynb
+++ b/notebooks/1. Beginning with Python.ipynb
@@ -176,7 +176,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**!!! Variable can can change type when re-assigned.**"
+    "**!!! Variable can change type when re-assigned.**"
    ]
   },
   {


### PR DESCRIPTION
Relates to Issue #47 