### PR TITLE
Remove `.idea` file from the repository

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml


### PR DESCRIPTION
This PR is to try and fix a bug when using PyCharm.

The issue:
* When I created a new PyCharm project by from version control by cloning this repo, the .idea folder caused a bug where PyCharm had no Python interpreter (and the menu options to create one were not present). This was fixed only by closing and opening the project, after which PyCharm correctly creates an interpreter for this project.
* After chatting with the PyCharm devs, they realised the .idea folder was likely causing this issue.
* After removing the .idea folder and committing the change, this indeed fixes the issue.