### PR TITLE
Add github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: 🐛 Bug Report
+about: Report a problem with the workshop materials or notebooks
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected Behavior
+
+A clear and concise description of what you expected to happen.
+
+## Screenshots
+
+If applicable, add screenshots to help explain your problem.
+
+## Environment
+
+- OS: (e.g., Windows, macOS, Linux)
+- Python version: (e.g., 3.10)
+- Miniconda version: (e.g., 23.1.0)
+- `uv` version (if applicable): (e.g., 0.1.36)
+- Jupyter Notebook/Lab version: (e.g., 7.0.0)
+
+## Additional Context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/content_suggestion.md
+++ b/.github/ISSUE_TEMPLATE/content_suggestion.md
@@ -1,0 +1,23 @@
+---
+name: 💡 Workshop Content Suggestion
+about: Suggest a new topic or improvement to the existing workshop material
+title: "[Content Suggestion] "
+labels: enhancement
+assignees: ''
+---
+
+## What's your suggestion?
+
+Briefly describe the topic or improvement you'd like to see.
+
+## Why is it useful?
+
+Explain how this would help learners or improve the workshop.
+
+## Any helpful resources or examples?
+
+(Optional) Link to tutorials, articles, or code that support your idea.
+
+## Additional Notes
+
+Anything else we should know?

--- a/.github/ISSUE_TEMPLATE/general_question.md
+++ b/.github/ISSUE_TEMPLATE/general_question.md
@@ -1,0 +1,19 @@
+---
+name: ❓ General Question
+about: Ask a question or seek clarification about the workshop materials
+title: "[Question] "
+labels: question
+assignees: ''
+---
+
+## Your Question
+
+Please provide a clear and concise question.
+
+## Context
+
+Provide any relevant context or background information.
+
+## Additional Information
+
+Add any other details or screenshots that might help.


### PR DESCRIPTION
## Add Issue Templates (#97 )
This PR adds standardized issue templates to improve learning and contribution experience:

🐛 bug_report.md – for reporting reproducible problems in workshop notebooks.

💡 content_suggestion.md – for proposing new workshop content or improvements.

❓ general_question.md – for asking questions or requesting clarification regarding the workshop content.