### PR TITLE
Consolidate setup instructions with resources page on Humble Data site

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ The materials can also be cloned from our [GitHub repo](https://github.com/Humbl
 
 Please contact us if you'd like to help out the project by translating the materials into other languages! 
 
-## Local environment setup
+### Installing the materials locally
+
+If you're interested in learning how to manage your own Python Environment you will need to install the materials locally. Instructions on how to do this are provided below. Don't worry if you've never done this before—these instructions are designed for complete beginners and will walk you through each step.
 
 To run these notebooks on on your machine you must set up a *Python environment*. This document contains instructions on how to run the workshop using either `uv` or `conda` (Miniconda).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ---
 ## Table of Contents
-* [Google Colab setup](#google-colab-setup)
+* [Accessing the materials in browser](#accessing-the-materials-in-browser)
 * [Local environment setup](#local-environment-setup)
 	+ [UV Installation](#uv-installation)
 	+ [Installing Miniconda](#installing-miniconda)
@@ -17,41 +17,17 @@
 * [License](#license)
 ---
 
-## Google Colab setup
+### Accessing the materials in browser
 
-1. Go to [https://githubtocolab.com/HumbleData/beginners-data-workshop](https://githubtocolab.com/HumbleData/beginners-data-workshop)
-2. Choose the notebook that you want to open
-   ![open a notebook in colab](media/colab/image10.png)
-3. Click on the file icon <img src="media/colab/image9.png" alt="file icon" width="30"/> on the left
-4. If you haven’t logged in to your Google account, you will be asked to do so
-   ![sign in to Google](media/colab/image2.png)
-5. At the beginning of the notebook, add a cell by clicking the <img src="media/colab/image8.png" alt="add code icon" width="60"/> button at the top
-   ![adding a code block](media/colab/image1.png)
-6. After that copy and paste the following codes in the new cell:
-   ```
-   !git clone https://github.com/HumbleData/beginners-data-workshop.git
-   !cp -r beginners-data-workshop/media/ .
-   !cp -r beginners-data-workshop/data/ .
-   !cp -r beginners-data-workshop/solutions/ .
-   !rm -r beginners-data-workshop/
-   ```
-   > NOTE: You will need to add this code cell to every notebook you start.
+During the workshop, we provide the materials for beginners using a JupyterLite server. The materials are currently available in [English](https://humbledata.org/online-workshop/lab/index.html), [Spanish](https://humbledata.org/online_workshop_spanish/lab/index.html) and [Italian](https://humbledata.org/online-workshop-italian-v2/lab/index.html). Please contact us if you'd like to help out the project by translating the materials into other languages!  
+**The easiest way to access the materials for beginners is to use our [JupyterLite](https://jupyterlite.readthedocs.io/en/stable/) server.** Select a language below to get started:
 
-   ![adding the script shown above](media/colab/image7.png)
-7. Run the cell by clicking the play button on the left of the cell or press shift \+ enter on your keyboard
-   ![running the script shown above](media/colab/image4.png)
-8. You may get this warning when running the first code block. Click “Run anyway” when asked (because you trust us not giving you malicious code).
-   ![warning about running code in colab](media/colab/image3.png)
-9. When the code is finished (it may take a moment), you should see that three folders are added to your files. Consider the preparation work done and you may now start using the notebook.
+The materials can also be cloned from our [GitHub repo](https://github.com/HumbleData/beginners-data-workshop). If you want to use the materials this way, you will need to install them locally. Instructions on how to do this are provided below. Don't worry if you've never done this before—these instructions are designed for complete beginners and will walk you through each step.
+- [English](https://humbledata.org/online-workshop/lab/index.html)
+- [Spanish](https://humbledata.org/online_workshop_spanish/lab/index.html)
+- [Italian](https://humbledata.org/online-workshop-italian-v2/lab/index.html).
 
-   <img src="media/colab/image5.png" alt="new files added" width="40%"/>
-10. Note that when you disconnect from the notebook (or leave it inactive for a long time) the files we just download with the code and your work is not saved.
-
-    Consider downloading or saving your work in drive before you leave this notebook. You can do so by clicking on the “File” button at the bottom.
-
-    <img src="media/colab/image6.png" alt="saving or downloading file to keep your work" width="60%"/>
-
----
+Please contact us if you'd like to help out the project by translating the materials into other languages! 
 
 ## Local environment setup
 


### PR DESCRIPTION
Right now we have several ways of setting up the workshop materials documented which could lead to confusion. I'm in favour updating the README as much as possible to match the brilliant new instructions from @t-redactyl here https://github.com/HumbleData/HumbleData.github.io/tree/updating-resources.

This change branch currently includes:

- Removing the Google Collab instructions entirely - only having one way of running the notebooks in browser can help to reduce confusion and the Jupyer Server implementation appears to me at least simpler for students

- Renaming the local install instructions to better emphasise that there are two options for accesing the workshop materials: using the jupyer server or manging your own local environment.

A completed version of this change would also include:

- Updating the rest of the README to match Jodie's instruction on the resources page, perhaps we could link there from the README instead of maintaining these docs in two places

The aim of this change is to simplify the experience of accessing materials both for students and also facilitators. 