### PR TITLE
docs: add Brazilian Portuguese workshop link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@
 
 ### Accessing the materials in browser
 
-During the workshop, we provide the materials for beginners using a JupyterLite server. The materials are currently available in [English](https://humbledata.org/online-workshop/lab/index.html), [Spanish](https://humbledata.org/online_workshop_spanish/lab/index.html) and [Italian](https://humbledata.org/online-workshop-italian-v2/lab/index.html). Please contact us if you'd like to help out the project by translating the materials into other languages!  
+During the workshop, we provide the materials for beginners using a JupyterLite server. The materials are currently available in [English](https://humbledata.org/online-workshop/lab/index.html), [Spanish](https://humbledata.org/online_workshop_spanish/lab/index.html), [Italian](https://humbledata.org/online-workshop-italian-v2/lab/index.html) and [Brazilian Portuguese](https://humbledata.org/online_workshop_ptbr/lab/index.html). Please contact us if you'd like to help out the project by translating the materials into other languages!  
 **The easiest way to access the materials for beginners is to use our [JupyterLite](https://jupyterlite.readthedocs.io/en/stable/) server.** Select a language below to get started:
 
 The materials can also be cloned from our [GitHub repo](https://github.com/HumbleData/beginners-data-workshop). If you want to use the materials this way, you will need to install them locally. Instructions on how to do this are provided below. Don't worry if you've never done this before—these instructions are designed for complete beginners and will walk you through each step.
 - [English](https://humbledata.org/online-workshop/lab/index.html)
 - [Spanish](https://humbledata.org/online_workshop_spanish/lab/index.html)
-- [Italian](https://humbledata.org/online-workshop-italian-v2/lab/index.html).
+- [Italian](https://humbledata.org/online-workshop-italian-v2/lab/index.html)
+- [Brazilian Portuguese](https://humbledata.org/online_workshop_ptbr/lab/index.html).
 
 Please contact us if you'd like to help out the project by translating the materials into other languages! 
 


### PR DESCRIPTION
## Summary

The Brazilian Portuguese edition of the workshop is now hosted at https://humbledata.org/online_workshop_ptbr/. This PR adds it to the language list in the README so people landing on the official repo discover it.

The deployment lives in [HumbleData/online_workshop_ptbr](https://github.com/HumbleData/online_workshop_ptbr), which mirrors the pattern used for Spanish/French/Italian. Translated source content is maintained at [PyLadiesSalvador/humbledata-iniciantes-ptbr](https://github.com/PyLadiesSalvador/humbledata-iniciantes-ptbr) and synced into the deploy repo via a sync script.

## Changes

- Inline language enumeration (line 22): add Brazilian Portuguese.
- Bullet list (lines 26-29): add the Brazilian Portuguese link.

## Test plan

- [ ] Verify the Portuguese link resolves to the JupyterLite site
- [ ] Confirm README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)