### PR TITLE
docs: add French workshop link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@
 
 ### Accessing the materials in browser
 
-During the workshop, we provide the materials for beginners using a JupyterLite server. The materials are currently available in [English](https://humbledata.org/online-workshop/lab/index.html), [Spanish](https://humbledata.org/online_workshop_spanish/lab/index.html) and [Italian](https://humbledata.org/online-workshop-italian-v2/lab/index.html). Please contact us if you'd like to help out the project by translating the materials into other languages!  
+During the workshop, we provide the materials for beginners using a JupyterLite server. The materials are currently available in [English](https://humbledata.org/online-workshop/lab/index.html), [Spanish](https://humbledata.org/online_workshop_spanish/lab/index.html), [Italian](https://humbledata.org/online-workshop-italian-v2/lab/index.html) and [French](https://humbledata.org/online-workshop-fr/). Please contact us if you'd like to help out the project by translating the materials into other languages!  
 **The easiest way to access the materials for beginners is to use our [JupyterLite](https://jupyterlite.readthedocs.io/en/stable/) server.** Select a language below to get started:
 
 The materials can also be cloned from our [GitHub repo](https://github.com/HumbleData/beginners-data-workshop). If you want to use the materials this way, you will need to install them locally. Instructions on how to do this are provided below. Don't worry if you've never done this before—these instructions are designed for complete beginners and will walk you through each step.
 - [English](https://humbledata.org/online-workshop/lab/index.html)
 - [Spanish](https://humbledata.org/online_workshop_spanish/lab/index.html)
-- [Italian](https://humbledata.org/online-workshop-italian-v2/lab/index.html).
+- [Italian](https://humbledata.org/online-workshop-italian-v2/lab/index.html)
+- [French](https://humbledata.org/online-workshop-fr/).
 
 Please contact us if you'd like to help out the project by translating the materials into other languages! 
 


### PR DESCRIPTION
## Summary

Adds the French edition of the workshop to the language list in the README. It's already deployed at https://humbledata.org/online-workshop-fr/ (source: [HumbleData/online-workshop-fr](https://github.com/HumbleData/online-workshop-fr)) and listed on the website's resources page, but the official repo README was missing it.

## Changes

- Inline language enumeration (line 22): add French.
- Bullet list (lines 26-29): add the French link.

## Test plan

- [ ] Verify the French link resolves to the JupyterLite site
- [ ] Confirm README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)